### PR TITLE
Feat: indexed props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,5 +19,7 @@
     "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
-  "rules": {}
+  "rules": {
+    "@typescript-eslint/no-inferrable-types": "off"
+  }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -54,6 +54,8 @@ type Item @entity {
   itemID: Bytes!
   "The data describing the item."
   data: String!
+  "The parsed data describing the item."
+  props: [ItemProp]! @derivedFrom(field: "item")
   "The current status of the item."
   status: Status!
   "List of status change requests made for the item in the form requests[requestID]."
@@ -72,6 +74,16 @@ type Item @entity {
   latestRequester: Bytes!
   "The account that challenged the latest request, if any."
   latestChallenger: Bytes!
+}
+
+type ItemProp @entity {
+  id: ID!
+  type: String!
+  label: String!
+  description: String!
+  isIdentifier: Boolean!
+  value: String
+  item: Item!
 }
 
 type Request @entity {

--- a/src/LightGeneralizedTCRMapping.ts
+++ b/src/LightGeneralizedTCRMapping.ts
@@ -105,7 +105,7 @@ let ZERO_ADDRESS = Bytes.fromHexString(
   '0x0000000000000000000000000000000000000000',
 ) as Bytes;
 
-function JSONValueToString(
+function JSONValueToMaybeString(
   value: JSONValue | null,
   _default: string | null = '',
 ): string | null {
@@ -186,11 +186,11 @@ export function handleNewItem(event: NewItem): void {
 
       let itemPropId = graphItemID + '@' + label.toString();
       let itemProp = new ItemProp(itemPropId);
-      itemProp.type = JSONValueToString(_type);
-      itemProp.label = JSONValueToString(label);
-      itemProp.description = JSONValueToString(description);
+      itemProp.type = JSONValueToMaybeString(_type);
+      itemProp.label = JSONValueToMaybeString(label);
+      itemProp.description = JSONValueToMaybeString(description);
       itemProp.isIdentifier = JSONValueToBool(isIdentifier);
-      itemProp.value = JSONValueToString(value);
+      itemProp.value = JSONValueToMaybeString(value);
       itemProp.item = item.id;
 
       itemProp.save();

--- a/src/LightGeneralizedTCRMapping.ts
+++ b/src/LightGeneralizedTCRMapping.ts
@@ -1,7 +1,17 @@
 /* eslint-disable prefer-const */
-import { Bytes, log, BigInt, Address } from '@graphprotocol/graph-ts';
+import {
+  Bytes,
+  BigInt,
+  Address,
+  ipfs,
+  json,
+  JSONValue,
+  JSONValueKind,
+  log,
+} from '@graphprotocol/graph-ts';
 import {
   Item,
+  ItemProp,
   Request,
   Round,
   Registry,
@@ -95,6 +105,43 @@ let ZERO_ADDRESS = Bytes.fromHexString(
   '0x0000000000000000000000000000000000000000',
 ) as Bytes;
 
+function JSONValueToString(
+  value: JSONValue | null,
+  _default: string | null = '',
+): string | null {
+  if (value == null || value.isNull()) {
+    return null;
+  }
+
+  switch (value.kind) {
+    case JSONValueKind.BOOL:
+      return value.toBool() == true ? 'true' : 'false';
+    case JSONValueKind.STRING:
+      return value.toString();
+    case JSONValueKind.NUMBER:
+      return value.toBigInt().toHexString();
+    default:
+      return _default;
+  }
+}
+
+function JSONValueToBool(value: JSONValue | null, _default: boolean = false): boolean {
+  if (value == null || value.isNull()) {
+    return _default;
+  }
+
+  switch (value.kind) {
+    case JSONValueKind.BOOL:
+      return value.toBool();
+    case JSONValueKind.STRING:
+      return value.toString() === 'true';
+    case JSONValueKind.NUMBER:
+      return value.toBigInt().notEqual(BigInt.fromString('0'));
+    default:
+      return _default;
+  }
+}
+
 export function handleNewItem(event: NewItem): void {
   // We assume this is an item added via addItemDirectly.
   // If it was emitted via addItem, all the missing data
@@ -118,6 +165,39 @@ export function handleNewItem(event: NewItem): void {
   item.latestRequestSubmissionTime = BigInt.fromI32(0);
 
   registry.numberOfItems = registry.numberOfItems.plus(BigInt.fromI32(1));
+
+  let jsonStr = ipfs.cat(item.data);
+  if (jsonStr != null) {
+    let jsonObj = json.fromBytes(jsonStr as Bytes).toObject();
+    let columns = jsonObj.get('columns').toArray();
+    let values = jsonObj.get('values').toObject();
+
+    for (let i = 0; i < columns.length; i++) {
+      let col = columns[i];
+      let colObj = col.toObject();
+
+      let label = colObj.get('label');
+
+      let description = colObj.get('description');
+      let _type = colObj.get('type');
+      let isIdentifier = colObj.get('isIdentifier');
+
+      let value = values.get(label.toString());
+
+      let itemPropId = graphItemID + '@' + label.toString();
+      let itemProp = new ItemProp(itemPropId);
+      itemProp.type = JSONValueToString(_type);
+      itemProp.label = JSONValueToString(label);
+      itemProp.description = JSONValueToString(description);
+      itemProp.isIdentifier = JSONValueToBool(isIdentifier);
+      itemProp.value = JSONValueToString(value);
+      itemProp.item = item.id;
+
+      itemProp.save();
+    }
+  } else {
+    log.error('Failed to fetch item #{} JSON: {}', [graphItemID, item.data]);
+  }
 
   item.save();
   registry.save();


### PR DESCRIPTION
This PR includes item props into the subgraph. Since there's defined no schema for items in a list, parameters are defined roughly as if they were in the [4th Normal Form](https://www.tutorialspoint.com/Fourth-Normal-Form-4NF).

A query for items with props will look like:

```graphql
{
  items {
    id
    props {
      type
      label
      description
      isIdentifier
      value
    }
  }
}
```

A couple of things to consider:
- There is no support for union types, so `value` is always a `string`. It's up to the UI to figure out the right type based on the `type` prop.
- There is no support for value objects in The Graph, so every prop is an entity whose ID is `<gtcr_addr>@<item_id>@<prop_label>`. I'm not sure how this impacts performance.
