### PR TITLE
chore: fix typo for id field of item

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -48,7 +48,7 @@ type MetaEvidence @entity {
 }
 
 type Item @entity {
-  "The id of the item in the subgraph entity. Format: <listaddress>@<itemID>"
+  "The id of the item in the subgraph entity. Format: <itemID>@<listaddress_lowercase>"
   id: ID!
   "The ID of the item in the registry. Also the keccak256 hash of the data."
   itemID: Bytes!


### PR DESCRIPTION
Previously it stated format of item id was <listaddress>@<itemID>, when it is <itemID>@<listaddress>
Made it <listaddress_lowercase> for clarity