### PR TITLE
Light GTCR usability improvements

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -73,6 +73,30 @@ type MetaEvidence @entity {
   URI: String!
 }
 
+type LEvidence @entity {
+  "<Request.id>-<evidence number>"
+  id: ID!
+  "The arbitrator's address."
+  arbitrator: Bytes!
+  "The ID of the evidence group (see {L,}Request.evidenceGroupID)."
+  evidenceGroupID: BigInt!
+  "The address of the party that sent this piece of evidence."
+  party: Bytes!
+  "The URI of the evidence file."
+  URI: String!
+  "The request this evidence belongs to."
+  request: LRequest
+  "This is the <number>th evidence submitted (starting at 0) for <request>."
+  number: BigInt!
+}
+
+type EvidenceGroupIDToLRequest @entity {
+  "<EvidenceGroupID>@<contract address>"
+  id: ID!
+  "LRequest ID"
+  request: LRequest!
+}
+
 type LItem @entity {
   "The id of the item in the subgraph entity. Format: <itemID>@<listaddress_lowercase>"
   id: ID!
@@ -165,6 +189,10 @@ type LRequest @entity {
   requestType: Status!
   "The URI to the meta evidence used for this request."
   metaEvidence: MetaEvidence!
+  "Evidence provided regarding this request (matching evidenceGroupID)."
+  evidences: [LEvidence!]! @derivedFrom(field: "request")
+  "Number of evidences."
+  numberOfEvidence: BigInt!
   "The item this request belongs to."
   item: LItem!
   "The registry where this request was submitted."

--- a/schema.graphql
+++ b/schema.graphql
@@ -82,6 +82,16 @@ type LItem @entity {
   data: String!
   "The parsed data describing the item."
   props: [ItemProp!]! @derivedFrom(field: "item")
+  "First indexable value of the json file."
+  key0: String
+  "Second indexable value of the json file."
+  key1: String
+  "Third indexable value of the json file."
+  key2: String
+  "Fourth indexable value of the json file."
+  key3: String
+  "Fifth indexable value of the json file."
+  key4: String
   "The item identifiers combined as a single string."
   keywords: String
   "The current status of the item."

--- a/src/LightGeneralizedTCRMapping.ts
+++ b/src/LightGeneralizedTCRMapping.ts
@@ -351,6 +351,7 @@ export function handleNewItem(event: NewItem): void {
   }
   let values = valuesValue.toObject();
 
+  let identifier = 0
   for (let i = 0; i < columns.length; i++) {
     let col = columns[i];
     let colObj = col.toObject();
@@ -375,6 +376,15 @@ export function handleNewItem(event: NewItem): void {
     itemProp.description = JSONValueToMaybeString(description);
     itemProp.isIdentifier = JSONValueToBool(isIdentifier);
     itemProp.item = item.id;
+
+    if (itemProp.isIdentifier) {
+      if (identifier == 0) item.key0 = itemProp.value
+      else if (identifier == 1) item.key1 = itemProp.value
+      else if (identifier == 2) item.key2 = itemProp.value
+      else if (identifier == 3) item.key3 = itemProp.value
+      else if (identifier == 4) item.key4 = itemProp.value
+      identifier += 1
+    }
 
     if (itemProp.isIdentifier && itemProp.value != null && item.keywords) {
       item.keywords = item.keywords + ' | ' + (itemProp.value as string);

--- a/src/LightGeneralizedTCRMapping.ts
+++ b/src/LightGeneralizedTCRMapping.ts
@@ -16,6 +16,8 @@ import {
   LRound,
   LRegistry,
   MetaEvidence,
+  LEvidence,
+  EvidenceGroupIDToLRequest,
   Arbitrator,
   LContribution,
 } from '../generated/schema';
@@ -31,6 +33,7 @@ import {
   ItemStatusChange,
   RequestSubmitted,
   MetaEvidence as MetaEvidenceEvent,
+  Evidence as EvidenceEvent,
   NewItem,
   RewardWithdrawn,
 } from '../generated/templates/LightGeneralizedTCR/LightGeneralizedTCR';
@@ -442,6 +445,7 @@ export function handleRequestSubmitted(event: RequestSubmitted): void {
   request.arbitratorExtraData = tcr.arbitratorExtraData();
   request.challenger = ZERO_ADDRESS;
   request.requester = event.transaction.from;
+  request.numberOfEvidence = BigInt.fromI32(0);
   request.item = item.id;
   request.registry = registry.id;
   request.registryAddress = event.address;
@@ -475,6 +479,11 @@ export function handleRequestSubmitted(event: RequestSubmitted): void {
     updateCounters(previousStatus, newStatus, event.address);
   }
 
+  let evidenceGroupIDToLRequest = new EvidenceGroupIDToLRequest(
+        event.params._evidenceGroupID.toString() + "@" + event.address.toHexString())
+  evidenceGroupIDToLRequest.request = requestID
+
+  evidenceGroupIDToLRequest.save()
   round.save();
   request.save();
   item.save();
@@ -865,4 +874,36 @@ export function handleMetaEvidence(event: MetaEvidenceEvent): void {
   }
 
   registry.save();
+}
+
+export function handleEvidence(event: EvidenceEvent): void {
+  let evidenceGroupIDToLRequest = EvidenceGroupIDToLRequest.load(
+        event.params._evidenceGroupID.toString() + "@" + event.address.toHexString());
+  if (!evidenceGroupIDToLRequest) {
+    log.error('EvidenceGroupID {} not registered for {}.',
+              [event.params._evidenceGroupID.toString(), event.address.toHexString()]);
+    return;
+  }
+
+  let request = LRequest.load(evidenceGroupIDToLRequest.request)
+  if (!request) {
+    log.error('Request {} not found.', [evidenceGroupIDToLRequest.request]);
+    return;
+  }
+
+  let evidence = new LEvidence(
+      request.id + '-' + request.numberOfEvidence.toString(),
+  );
+
+  evidence.arbitrator = event.params._arbitrator;
+  evidence.evidenceGroupID = event.params._evidenceGroupID;
+  evidence.party = event.params._party;
+  evidence.URI = event.params._evidence;
+  evidence.request = request.id;
+  evidence.number = request.numberOfEvidence;
+
+  request.numberOfEvidence = request.numberOfEvidence.plus(BigInt.fromI32(1));
+
+  request.save();
+  evidence.save();
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -86,6 +86,8 @@ templates:
           handler: handleRewardWithdrawn
         - event: MetaEvidence(indexed uint256,string)
           handler: handleMetaEvidence
+        - event: Evidence(indexed address,indexed uint256,indexed address,string)
+          handler: handleEvidence
       file: ./src/LightGeneralizedTCRMapping.ts
   - kind: ethereum/contract
     name: LIArbitrator
@@ -96,7 +98,7 @@ templates:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
-      entities: 
+      entities:
         - Arbitrator
       abis:
         - name: IArbitrator
@@ -151,7 +153,7 @@ templates:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
-      entities: 
+      entities:
         - Item
         - Request
         - Round


### PR DESCRIPTION
Requesting code review.

Not sure the key{0..4} thing is the best approach but it seemed to be the only solution which enables elegantly and safely searching for an item which has a specific combination of properties.

Regarding the Evidence, I had to add an EvidenceGroupIDToLRequest @entity which is only useful to build the graph. There might be a better solution but if so, I couldn't find it.